### PR TITLE
Add grunt-cli to package file

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "version": "0.0.1",
   "dependencies": {
     "grunt": "~0.4.0",
+    "grunt-cli": "~0.1.9",
     "grunt-contrib-connect": "0.2.0",
     "grunt-contrib-concat": "0.1.3",
     "grunt-contrib-uglify": "0.2.0"


### PR DESCRIPTION
See http://stackoverflow.com/questions/10667381/node-package-grunt-installed-but-not-available for explanation as to why cli should be listed separately
