### PR TITLE
three.js should be a dependency not a devDependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "node_modules",
     "bower_components"
   ],
-  "devDependencies": {
+  "dependencies": {
     "threejs": "r67"
   }
 }


### PR DESCRIPTION
since it needs to be fetched when installed via bower in other projects
