### PR TITLE
Using default suffix option of gulp-rename

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,8 +45,8 @@ gulp.task('build', function() {
     .pipe(banner())
     .pipe(gulp.dest('build'))
     .pipe(uglify())
-    .pipe(rename(function(filepath) {
-      filepath.basename += '-min';
+    .pipe(rename({
+      suffix: '-min'
     }))
     .pipe(banner())
     .pipe(gulp.dest('build'));
@@ -56,8 +56,8 @@ gulp.task('build-data', function() {
   return gulp.src('src/detection/training/haar/**.js')
     .pipe(banner())
     .pipe(gulp.dest('build/data'))
-    .pipe(rename(function(filepath) {
-      filepath.basename += '-min';
+    .pipe(rename({
+      suffix: '-min'
     }))
     .pipe(uglify())
     .pipe(banner())


### PR DESCRIPTION
The gulp-rename plugin has a default option for suffix, would not better use this option?
