### PR TITLE
Magenta screen page

### DIFF
--- a/examples/color_fish_tank.html
+++ b/examples/color_fish_tank.html
@@ -22,7 +22,7 @@
 </head>
 <body>
   <div class="demo-title">
-    <p><a href="http://trackingjs.com" target="_parent">tracking.js</a> － use a magenta colored object to control the scene</p>
+    <p><a href="http://trackingjs.com" target="_parent">tracking.js</a> － use a magenta colored object to control the scene or <a href="color_magenta_screen.html" target="_parent">open get.al/magenta on mobile</a></p>
   </div>
 
   <video id="video" width="320" height="240" preload autoplay loop muted></video>

--- a/examples/color_magenta_screen.html
+++ b/examples/color_magenta_screen.html
@@ -1,0 +1,35 @@
+<!doctype html>
+
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>tracking.js - magenta screen</title>
+  <link rel="stylesheet" href="assets/demo.css">
+
+  <script src="../build/tracking-min.js"></script>
+  <script src="../../dat-gui/build/dat.gui.min.js"></script>
+
+  <style>
+  .demo-frame-mobile {
+    background-color: magenta;
+    
+    width: 100%;
+    height: 100vh;
+  }
+  
+
+
+  </style>
+</head>
+<body>
+  <div class="demo-title">
+    <p><a href="http://trackingjs.com" target="_parent">tracking.js</a> － magenta screen for demo - open on mobile</p>
+  </div>
+
+  <div class="demo-frame-mobile">
+    
+  </div>
+
+
+</body>
+</html>


### PR DESCRIPTION
The Random Particles demo (color_fish_tank.html) requires a magenta colored object. One possible way is having a magenta screen on your mobile, which acts as the required magenta colored object. It's accurate too. 

So I have done the following changes
- Added a magenta full screen  -> color_magenta_screen.html . It follows the same layout as the other pages with a bar on the top and link to tracking.js homepage.
- Created a short url get.al/magenta so that it can be quickly accessed on mobile. It links to https://trackingjs.com/examples/color_magenta_screen.html
- Added a message on color_fish_tank.html to access the short url.




