### PR TITLE
examples: fix dat.gui refs & add dat.gui to devDeps

### DIFF
--- a/examples/brief.html
+++ b/examples/brief.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="assets/demo.css">
 
   <script src="../build/tracking-min.js"></script>
-  <script src="../../dat-gui/build/dat.gui.min.js"></script>
+  <script src="../node_modules/dat.gui/build/dat.gui.min.js"></script>
 
   <style>
   .demo-container {

--- a/examples/brief_camera.html
+++ b/examples/brief_camera.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="assets/demo.css">
 
   <script src="../build/tracking-min.js"></script>
-  <script src="../../dat-gui/build/dat.gui.min.js"></script>
+   <script src="../node_modules/dat.gui/build/dat.gui.min.js"></script>
   <script src="assets/stats.min.js"></script>
 
   <style>

--- a/examples/color_camera.html
+++ b/examples/color_camera.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="assets/demo.css">
 
   <script src="../build/tracking-min.js"></script>
-  <script src="../../dat-gui/build/dat.gui.min.js"></script>
+  <script src="../node_modules/dat.gui/build/dat.gui.min.js"></script>
   <script src="assets/stats.min.js"></script>
   <script src="assets/color_camera_gui.js"></script>
 

--- a/examples/color_video.html
+++ b/examples/color_video.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="assets/demo.css">
 
   <script src="../build/tracking-min.js"></script>
-  <script src="../../dat-gui/build/dat.gui.min.js"></script>
+   <script src="../node_modules/dat.gui/build/dat.gui.min.js"></script>
   <script src="assets/stats.min.js"></script>
   <script src="assets/color_camera_gui.js"></script>
 

--- a/examples/face_camera.html
+++ b/examples/face_camera.html
@@ -7,7 +7,7 @@
 
   <script src="../build/tracking-min.js"></script>
   <script src="../build/data/face-min.js"></script>
-  <script src="../../dat-gui/build/dat.gui.min.js"></script>
+   <script src="../node_modules/dat.gui/build/dat.gui.min.js"></script>
   <script src="assets/stats.min.js"></script>
 
   <style>

--- a/examples/fast.html
+++ b/examples/fast.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="assets/demo.css">
 
   <script src="../build/tracking-min.js"></script>
-  <script src="../../dat-gui/build/dat.gui.min.js"></script>
+   <script src="../node_modules/dat.gui/build/dat.gui.min.js"></script>
 
   <style>
   .demo-container {

--- a/examples/fast_camera.html
+++ b/examples/fast_camera.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="assets/demo.css">
 
   <script src="../build/tracking-min.js"></script>
-  <script src="../../dat-gui/build/dat.gui.min.js"></script>
+  <script src="../node_modules/dat.gui/build/dat.gui.min.js"></script>
   <script src="assets/stats.min.js"></script>
 
   <style>

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "jshint-stylish": "^2.1.0",
     "nodeunit": "^0.9.1",
     "png-js": "^0.1.1",
-    "run-sequence": "^1.1.5"
+    "run-sequence": "^1.1.5",
+    "dat.gui": "^0.6.1"
   }
 }


### PR DESCRIPTION
In order to fix the examples, I think it would be appropriate to add it to devDependencies instead of dependencies or adding a binary of this package into master.

This issue was referenced at https://github.com/eduardolundgren/tracking.js/issues/135