### PR TITLE
Allow custom constraints to be passed to getUserMedia()

### DIFF
--- a/src/tracking.js
+++ b/src/tracking.js
@@ -55,10 +55,17 @@
    * @param {object} opt_options Optional configuration to the tracker.
    */
   tracking.initUserMedia_ = function(element, opt_options) {
-    window.navigator.mediaDevices.getUserMedia({
+    
+    var constraints = {
       video: true,
       audio: (opt_options && opt_options.audio) ? true : false,
-    }).then(function(stream) {
+    };
+
+    if (opt_options && opt_options.mediaConstraints) {
+      constraints = opt_options.mediaConstraints;
+    }
+
+    window.navigator.mediaDevices.getUserMedia(constraints).then(function(stream) {
       element.srcObject = stream;
     }).catch(function(err) {
       throw Error('Cannot capture user camera.');


### PR DESCRIPTION
There is currently no way to control the webcam media constraints. This PR changes that by allowing you to pass a `mediaConstraints` property in the `options` parameter of `tracking.track()`.

This would be very useful if you want, for example, to use a low-res feed for faster color tracking or if you need to pick a specific webcam out of many.

The suggested implementation is backwards-compatible.