### PR TITLE
tracking.trackImg_: using naturalWidth, naturalHeight

### DIFF
--- a/src/tracking.js
+++ b/src/tracking.js
@@ -196,8 +196,8 @@
    * @private
    */
   tracking.trackImg_ = function(element, tracker) {
-    var width = element.width;
-    var height = element.height;
+    var width = element.naturalWidth;
+    var height = element.naturalHeight;
     var canvas = document.createElement('canvas');
 
     canvas.width = width;


### PR DESCRIPTION
using width, height to obtain the dimensions of a image will return the css scaled dimensions, not the real dimensions of the image. by using naturalWidth, naturalHeight instead, the canvas will be created with the same pixel dimensions that the original image, not the incorrect scaled size given to the image by the css rules. 