### PR TITLE
Add CDN usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The tracking.js library brings different computer vision algorithms and techniqu
 
 ## Install
 
-Install via [Bower](http://bower.io/), [npm](https://www.npmjs.com/), or [download as a zip](https://github.com/eduardolundgren/tracking.js/archive/master.zip):
+Install via [Bower](http://bower.io/), [npm](https://www.npmjs.com/), [download as a zip](https://github.com/eduardolundgren/tracking.js/archive/master.zip), or include it directly via [CDN](https://www.jsdelivr.com/package/npm/tracking):
 
 ```
 bower install tracking
@@ -19,6 +19,10 @@ bower install tracking
 
 ```
 npm install tracking
+```
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/tracking"></script>
 ```
 
 ## Examples


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/) to the readme as it is easier and faster than downloading.