### PR TITLE
docs: Fix simple typo, graysacaled -> grayscale

### DIFF
--- a/build/tracking.js
+++ b/build/tracking.js
@@ -1412,7 +1412,7 @@
   tracking.Fast.circles_ = {};
 
   /**
-   * Finds corners coordinates on the graysacaled image.
+   * Finds corners coordinates on the grayscale image.
    * @param {array} The grayscale pixels in a linear [p1,p2,...] array.
    * @param {number} width The image width.
    * @param {number} height The image height.

--- a/src/features/Fast.js
+++ b/src/features/Fast.js
@@ -41,7 +41,7 @@
   tracking.Fast.circles_ = {};
 
   /**
-   * Finds corners coordinates on the graysacaled image.
+   * Finds corners coordinates on the grayscale image.
    * @param {array} The grayscale pixels in a linear [p1,p2,...] array.
    * @param {number} width The image width.
    * @param {number} height The image height.


### PR DESCRIPTION
There is a small typo in build/tracking.js, src/features/Fast.js.

Should read `grayscale` rather than `graysacaled`.

